### PR TITLE
Updated Rotary Encoder Usage example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Rotary Encoder Usage
     encoder = gaugette.rotary_encoder.RotaryEncoder(gpio, A_PIN, B_PIN)
     encoder.start()
     while True:
-      delta = encoder.get_delta()
+      delta = encoder.get_cycles()
       if delta!=0:
         print "rotate %d" % delta
       else:


### PR DESCRIPTION
Didn't work for me as is, so I changed encoder.get_delta() to encoder.get_cycles()

Sorry for two pull requests. I made the first before I found this change.