### PR TITLE
Adding callback functionality to the rotary encoder

### DIFF
--- a/gaugette/rotary_encoder.py
+++ b/gaugette/rotary_encoder.py
@@ -48,7 +48,7 @@ class RotaryEncoder:
 
         # Callback function gets called when a rotation is detected
         # Function format should be:
-        # FuncName(x) where x is 1 or -1 depending on the detected roation
+        # FuncName(x) where x is 1 or -1 depending on the detected rotation
         # direction
         self.callback = callback
 

--- a/gaugette/rotary_encoder.py
+++ b/gaugette/rotary_encoder.py
@@ -34,7 +34,7 @@ class RotaryEncoder:
     # Pass the wiring pin numbers here.  See:
     #  https://projects.drogon.net/raspberry-pi/wiringpi2/pins/
     #----------------------------------------------------------------------
-    def __init__(self, gpio, a_pin, b_pin):
+    def __init__(self, gpio, a_pin, b_pin, callback=None):
         self.gpio = gpio
         self.a_pin = a_pin
         self.b_pin = b_pin
@@ -45,6 +45,12 @@ class RotaryEncoder:
         self.steps = 0
         self.last_delta = 0
         self.r_seq = self.rotation_sequence()
+
+        # Callback function gets called when a rotation is detected
+        # Function format should be:
+        # FuncName(x) where x is 1 or -1 depending on the detected roation
+        # direction
+        self.callback = callback
 
         # steps_per_cycle and self.remainder are only used in get_cycles which
         # returns a coarse-granularity step count.  By default
@@ -94,6 +100,11 @@ class RotaryEncoder:
             self.last_delta = delta
             self.r_seq = r_seq
         self.steps += delta
+        if(self.callback is not None):
+            cycles = self.get_cycles()
+            if(cycles != 0):
+                self.callback(cycles)
+            
 
     def get_steps(self):
         steps = self.steps

--- a/gaugette/switch.py
+++ b/gaugette/switch.py
@@ -12,10 +12,7 @@ class Switch:
     # edge = gpio.EDGE_FALLING or gpio.EDGE_RISING
     # isr = interrupt service routine
     def enable_isr(self, edge, isr):
-        if edge:
-            self.gpio.trigger(self.pin, edge, isr)
-        else:
-            self.gpio.trigger(self.pin, edge, isr)
+        self.gpio.trigger(self.pin, edge, isr)
 
     def get_state(self):
         state = self.gpio.input(self.pin)

--- a/gaugette/switch.py
+++ b/gaugette/switch.py
@@ -9,6 +9,14 @@ class Switch:
         pull_up_mode = gpio.PUD_UP if pull_up else gpio.PUD_DOWN
         self.gpio.setup(self.pin, self.gpio.IN, pull_up_mode)
 
+    # edge = gpio.EDGE_FALLING or gpio.EDGE_RISING
+    # isr = interrupt service routine
+    def enable_isr(self, edge, isr):
+        if edge:
+            self.gpio.trigger(self.pin, edge, isr)
+        else:
+            self.gpio.trigger(self.pin, edge, isr)
+
     def get_state(self):
         state = self.gpio.input(self.pin)
         if self.pull_up:

--- a/samples/rotary_callback.py
+++ b/samples/rotary_callback.py
@@ -1,0 +1,21 @@
+# Sample code for both the RotaryEncoder class and the Switch class.
+# The common pin for the encoder should be wired to ground.
+# The sw_pin should be shorted to ground by the switch.
+
+import time
+import gaugette.gpio
+import gaugette.rotary_encoder
+
+# Rotary encoder pins
+A_PIN = 23
+B_PIN = 22
+
+def rotated(direction):
+    print("Rotated ", direction)
+
+gpio = gaugette.gpio.GPIO()
+encoder = gaugette.rotary_encoder.RotaryEncoder(gpio, A_PIN, B_PIN, rotated)
+encoder.start()
+
+while True:
+    time.sleep(100)

--- a/samples/switch_isr.py
+++ b/samples/switch_isr.py
@@ -1,0 +1,20 @@
+# Sample code for both the RotaryEncoder class and the Switch class.
+# The common pin for the encoder should be wired to ground.
+# The sw_pin should be shorted to ground by the switch.
+
+import time
+import gaugette.gpio
+import gaugette.switch
+
+SW_PIN = 21
+
+def pushed():
+    print("Switch pushed!")
+
+gpio = gaugette.gpio.GPIO()
+sw = gaugette.switch.Switch(gpio, SW_PIN)
+# Calls pushed() on a rising edge
+sw.enable_isr(gpio.EDGE_FALLING, pushed)
+
+while True:
+    time.sleep(100)

--- a/samples/switch_isr.py
+++ b/samples/switch_isr.py
@@ -13,7 +13,7 @@ def pushed():
 
 gpio = gaugette.gpio.GPIO()
 sw = gaugette.switch.Switch(gpio, SW_PIN)
-# Calls pushed() on a rising edge
+# Calls pushed() on a falling edge
 sw.enable_isr(gpio.EDGE_FALLING, pushed)
 
 while True:


### PR DESCRIPTION
Because the rotary encoder library changed to interrupt based checks, it is now possible to use a callback function. When a rotation is detected, the callback function is called.